### PR TITLE
Added utf8 to the read and write file staments and added ensure_ascii…

### DIFF
--- a/markdown_to_json/scripts/md_to_json.py
+++ b/markdown_to_json/scripts/md_to_json.py
@@ -43,7 +43,7 @@ def writable_io_or_stdout(filename):
         return
     else:
         try:
-            f = open(filename, 'w')
+            f = open(filename, 'w', encoding='utf8')
             yield f
             f.close()
         except:
@@ -54,7 +54,7 @@ def writable_io_or_stdout(filename):
 
 def get_markdown_ast(markdown_file):
     try:
-        f = open(markdown_file, 'r')
+        f = open(markdown_file, 'r', encoding='utf8')
         return CommonMark.DocParser().parse(f.read())
     except:
         logging.error("Error: Can't open {0} for reading".format(
@@ -71,7 +71,7 @@ def jsonify_markdown(markdown_file, outfile, indent):
         ast = get_markdown_ast(markdown_file)
         nested = nester.nest(ast)
         rendered = renderer.stringify_dict(nested)
-        json.dump(rendered, f, indent=indent)
+        json.dump(rendered, f, indent=indent, ensure_ascii=False)
         f.write("\n")
     return 0
 


### PR DESCRIPTION
I was trying to use the library to create a JSON translation file in Spanish but I have problems with Spanish characters as ÁÉÍÓÚÑ. I try some of the ideas on the Issues but it didn't work. After troubleshooting the code this morning I found that a small change on the read, write, and JSON dump statements could fix the problem.

I'm using Python 3.7.4 and Windows 10.

…=False on JSON dump so the library can be use with Spanish characters and run on Windows