### PR TITLE
Fix HTMLunescape for Python 3.9 (njvack/markdown-to-json#12)

### DIFF
--- a/markdown_to_json/vendor/CommonMark/CommonMark.py
+++ b/markdown_to_json/vendor/CommonMark/CommonMark.py
@@ -16,7 +16,7 @@ if sys.version_info >= (3, 0):
     import urllib.parse
     if sys.version_info >= (3, 4):
         import html.parser
-        HTMLunescape = html.parser.HTMLParser().unescape
+        HTMLunescape = html.unescape
     else:
         from .entitytrans import _unescape
         HTMLunescape = _unescape


### PR DESCRIPTION
Trivial one-line change to make this work with more recent versions of Python (see issue #12)