### PR TITLE
allow empty list block

### DIFF
--- a/markdown_to_json/markdown_to_json.py
+++ b/markdown_to_json/markdown_to_json.py
@@ -172,7 +172,7 @@ class Renderer:
         if len(block.children) > 0:
             return [self._render_block(b) for b in block.children]
         # Is this an error state?
-        return None
+        return []
 
     # function name called based on block type
     # pylint: disable=invalid-name


### PR DESCRIPTION
otherwise it will report error like
```
  File "/.local/lib/python3.11/site-packages/markdown_to_json/markdown_to_json.py", line 184, in _render_List
    return reduce(operator.add, list_items)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: can only concatenate list (not "NoneType") to list

```